### PR TITLE
Fix tool argument passing and clean session types

### DIFF
--- a/include/ChatSession.hpp
+++ b/include/ChatSession.hpp
@@ -1,42 +1,18 @@
-// 定义管理聊天记录的类定义
-#include<string>
-#include<vector>
-#include<nlohmann/json.hpp>
-/*
-ChatSession 类负责维护多轮对话的历史记录，并提供消息裁剪和Token统计等功能，以防止上下文过长。主要特性包括：
-对话消息存储： 使用适当的数据结构（例如std::vector）保存消息序列，每条消息包含角色和内容。典型的角色有：
-"user"：用户消息,"assistant"：AI助手回复,"tool"：工具返回结果（用于函数调用机制）可以定义一个结构体如Message存储role和content字段。）
-Token 计数与裁剪： 跟踪当前会话的Token数量。当新增消息使总Tokens超过阈值时，裁剪最早的消息以保持上下文长度在允许范围。settings.json中可能有配置如"max_tokens"或"clip_threshold"指定阈值
-*/
-// 模块调用
-/*
-ChatSession 提供简洁的接口供外部使用。
-例如 BotService 每当有新用户输入或新AI回复时，
-就调用 ChatSession.addUserMessage(...) 或 addAssistantMessage(...) 记录下来。
-在发送请求给模型之前，BotService 调用 getMessagesJson() 获取历史记录的JSON表示。
-裁剪逻辑在新增消息时自动进行，对外透明
-*/
-class ChatSession{
-    public:
-        ChatSession(size_t maxToekns);  //构造函数,初始化maxTokens,清空messages,设toeknCount为0;
-        void addUserMessage(const std::string& content); 
-        //添加一条信息进入messages:建立一个Message对象,role="user"
-        //考虑:1.使用util.hpp中的Token估算工具计算此消息的Token长度，累加到tokenCount
-        //2.调用内部裁剪函数（如trimHistory()），若当前tokenCount超出maxTokens，则从最早的消息开始移除，直到tokenCount降至阈值以
-        void addAssistantMessage(const std::string& content);
-        //与addUserMessage相似,role="assistant"
-        void addToolResultMessage(const std::string& toolName, const std::string& result);
-        //添加一条工具函数执行结果消息
-        //创建Message {role: "tool", content: result} 并可能附加工具名，用于告知模型这是哪个函数的输出。例如可以在Message结构中新增name字段存放工具名。将此消息追加到历史，更新token计数并裁剪。
-        //在Ollama工具功能中，使用角色"tool"携带结果和函数名是约定做法，模型会据此继续回答
-        std::vector<nlohmann::json> getMessagesJson() const;
-        void trimHistory();
-    private:
-        struct Message{                 // 考虑Ollama的接口规格?           
-            std::string role;
-            std::string content;
-        };
-        std::vector<Message>messages;   // 存储所有对话消息
-        size_t tokenCount;              // 当前消息总的Token估算数
-        size_t maxSize;               // Token阈值（从配置加载）
+#pragma once
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+// ChatSession 用于维护对话历史并在超出阈值时裁剪最旧的记录
+class ChatSession {
+public:
+    explicit ChatSession(size_t maxSize);
+    void addUserMessage(const std::string& content);
+    void addAssistantMessage(const std::string& content);
+    void addToolResultMessage(const std::string& toolName, const std::string& result);
+    std::vector<nlohmann::json> getMessagesJson() const;
+    void trimHistory();
+private:
+    std::vector<nlohmann::json> messages;
+    size_t maxSize;
 };

--- a/include/ToolRegistry.hpp
+++ b/include/ToolRegistry.hpp
@@ -1,63 +1,25 @@
-// 工具注册与管理
+#pragma once
+#include <nlohmann/json.hpp>
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
-/*
-ToolRegistry 类管理本地可调用工具函数的注册和调度。
-模型通过调用这些工具，获取额外的信息或计算结果（类似 OpenAI 的函数调用能力）。
-ToolRegistry 提供工具元数据（名称、参数说明等）给模型，并在运行时根据模型请求调用相应的C++函数实现。
-*/
-#include<string>
-#include<nlohmann/json.hpp>
 struct ToolInfo {
-    std::string name;        // 工具函数名称（供模型调用）
-    std::string description; // 描述
-    nlohmann::json paramSchema; // 参数JSON模式定义 (JSON Schema 格式)
-    /* 
-    "type": "object",
-    "properties": {
-      "参数1": {
-        "type": "string",
-        "description": "参数1描述"
-      },
-      "参数2": {
-        "type": "integer",
-        "description": "参数2描述"
-      }
-    */
-    std::function<std::string(const nlohmann::json&)> handler; // 工具实现函数，传入参数JSON，返回结果字符串
+    std::string name;
+    std::string description;
+    nlohmann::json paramSchema;
+    std::function<std::string(const nlohmann::json&)> handler;
 };
+
 class ToolRegistry {
 private:
-    std::unordered_map<std::string, ToolInfo> tools; // 已注册工具映射表(name -> ToolInfo)
+    std::unordered_map<std::string, ToolInfo> tools;
 public:
-    void registerTool(
-        const std::string& name, 
-        const std::string& description, 
-        const nlohmann::json& paramSchema, 
-        std::function<std::string(const nlohmann::json&)> handler
-        );
-        // 注册一个工具
-        /*
-        实现： 将工具名称和对应的ToolInfo存入tools映射，以名称为键方便查找。
-        paramSchema 定义了此函数的参数要求（采用 JSON Schema 格式，与Ollama工具接口匹配），
-        handler是实际执行的C++函数。
-        */
+    void registerTool(const std::string& name,
+                      const std::string& description,
+                      const nlohmann::json& paramSchema,
+                      std::function<std::string(const nlohmann::json&)> handler);
     ToolInfo* getToolInfo(const std::string& name);
-    // 根据名称获取工具信息结构指针
-    /*
-    用途： BotService在收到模型请求要调用某工具时，
-    会通过名称从注册表查询对应的ToolInfo
-    （尤其需要其中的handler以调用实现）
-    */
     std::vector<nlohmann::json> getToolDefinitionsJson() const;
-    //获取所有工具的JSON定义列表，供发送给模型接口
-    /*
-    实现： 遍历已注册工具，将每个ToolInfo转换为Ollama API期望的格式
-    */
-    
 };
-/*
-模块间交互：
-初始化时，ToolRegistry由各工具cpp调用registerTool添加工具。
-在对话过程中，当BotService检测到模型输出包含tool_calls请求时，会使用ToolRegistry.getToolInfo(name)找到对应工具，然后调用其中的handler执行，并获取结果。
-同时，在每次发送请求给模型时，BotService会调用ToolRegistry.getToolDefinitionsJson()将工具列表提供给模型，使其有权限调这些函数。
-*/

--- a/src/BotService.cpp
+++ b/src/BotService.cpp
@@ -1,5 +1,6 @@
 #include "BotService.hpp"
 #include <iostream>
+#include <nlohmann/json.hpp>
 
 BotService::BotService(
     const ChatSession& session,
@@ -32,8 +33,9 @@ std::string BotService::processUserMessage(const std::string& userInput){
                 
                 for (const auto& toolCall : json["tool_calls"]) {
                     std::string toolName = toolCall["name"].get<std::string>();
-                    std::string arguments = toolCall["arguments"].get<std::string>();
-                    
+                    nlohmann::json arguments =
+                        nlohmann::json::parse(toolCall["arguments"].get<std::string>());
+
                     // 查找并执行工具
                     auto* toolInfo = toolRegistry.getToolInfo(toolName);
                     if (toolInfo) {

--- a/src/ChatSession.cpp
+++ b/src/ChatSession.cpp
@@ -1,28 +1,31 @@
 #include "ChatSession.hpp"
-#include<string>
-#include<vector>
-ChatSession::ChatSession(size_t maxSize){
-    this->maxSize = maxSize;
-    this->messages.clear();
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+ChatSession::ChatSession(size_t maxSize) : maxSize(maxSize) {}
+
+void ChatSession::addUserMessage(const std::string& content) {
+    messages.push_back({{"role", "user"}, {"content", content}});
+    trimHistory();
 }
 
-void ChatSession::addUserMessage(const std::string& content){
-    this->messages.push_back({{"role", "user"}, {"content", content}});
+void ChatSession::addAssistantMessage(const std::string& content) {
+    messages.push_back({{"role", "assistant"}, {"content", content}});
     trimHistory();
 }
-void ChatSession::addAssistantMessage(const std::string& content){
-    this->messages.push_back({{"role", "assistant"}, {"content", content}});
+
+void ChatSession::addToolResultMessage(const std::string& toolName, const std::string& result) {
+    messages.push_back({{"role", "tool"}, {"content", result}, {"name", toolName}});
     trimHistory();
 }
-void ChatSession::addToolResultMessage(const std::string& toolName, const std::string& result){
-    this->messages.push_back({{"role", "tool"}, {"content", result}, {"name", toolName}});
-    trimHistory();
+
+std::vector<nlohmann::json> ChatSession::getMessagesJson() const {
+    return messages;
 }
-std::vector<nlohmann::json> ChatSession::getMessagesJson() const{
-    return this->messages;
-}
-void ChatSession::trimHistory(){
-    while (this->messages.size() > this->maxSize){
-        this->messages.erase(this->messages.begin());
+
+void ChatSession::trimHistory() {
+    while (messages.size() > maxSize) {
+        messages.erase(messages.begin());
     }
-}   
+}


### PR DESCRIPTION
## Summary
- clean up `ChatSession` class to store JSON messages directly
- simplify `ToolRegistry` header
- parse tool arguments as JSON in `BotService`
- minor includes

## Testing
- `cmake ..` *(fails: Could not find cprConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68687c0aea9c8321b4382c543ca6202e